### PR TITLE
only normalize URLs for http, ftp, or without scheme. Fixes #10

### DIFF
--- a/lib/normalize_url.ex
+++ b/lib/normalize_url.ex
@@ -21,6 +21,16 @@ defmodule NormalizeUrl do
   Returns a url as a string.
   """
   def normalize_url(url, options \\ []) do
+    %{scheme: scheme} = URI.parse(url)
+
+    if (scheme == "http") || (scheme == "ftp") || (scheme == nil) do
+      normalize_http_or_ftp_url(url, options)
+    else
+      url
+    end
+  end
+
+  defp normalize_http_or_ftp_url(url, options \\ []) do
     options = Keyword.merge([
       normalize_protocol: true,
       strip_www: true,
@@ -82,4 +92,5 @@ defmodule NormalizeUrl do
 
     scheme <> host_and_path <> query_params
   end
+
 end

--- a/test/normalize_url_test.exs
+++ b/test/normalize_url_test.exs
@@ -14,6 +14,14 @@ defmodule NormalizeUrlTest do
     assert(NormalizeUrl.normalize_url("https://google.com") == "https://google.com")
   end
 
+  test "keeps the mailto protocol" do
+    assert(NormalizeUrl.normalize_url("mailto:joe@example.com") == "mailto:joe@example.com")
+  end
+
+  test "keeps the javascript protocol" do
+    assert(NormalizeUrl.normalize_url("javascript:alert('hey')") == "javascript:alert('hey')")
+  end
+
   test "handles ftp protocols" do
     assert(NormalizeUrl.normalize_url("ftp://google.com") == "ftp://google.com")
   end


### PR DESCRIPTION
Hello, as currently normalize_url only deals with the HTTP(s) or FTP schemes, I've added this workaround to just return the URL unchanged in other cases, like `mailto:`, `javascript:`, and other schemes.
