### PR TITLE
Encodes back query params after sorting them.

### DIFF
--- a/lib/normalize_url.ex
+++ b/lib/normalize_url.ex
@@ -84,9 +84,7 @@ defmodule NormalizeUrl do
 
     query_params = ""
     if uri.query do
-      query_params_dict = URI.decode_query(uri.query)
-      sorted_query_params = Enum.map(query_params_dict, fn{k, v} -> "#{k}=#{v}" end)
-                            |> Enum.join("&")
+      sorted_query_params = uri.query |> URI.decode_query |> URI.encode_query
       query_params = "?" <> sorted_query_params
     end
 

--- a/test/normalize_url_test.exs
+++ b/test/normalize_url_test.exs
@@ -50,6 +50,10 @@ defmodule NormalizeUrlTest do
     assert(NormalizeUrl.normalize_url("google.com?b=foo&a=bar&123=hi") == "http://google.com?123=hi&a=bar&b=foo")
   end
 
+  test "encodes back query params" do
+    assert(NormalizeUrl.normalize_url("google.com?b=foo's+bar&a=joe+smith") == "http://google.com?a=joe+smith&b=foo%27s+bar")
+  end
+
   test "strips url fragment" do
     assert(NormalizeUrl.normalize_url("johnotander.com#about") == "http://johnotander.com")
   end


### PR DESCRIPTION
When sorting query params, they were being decoded but not encoded back. So if the params included special characters, the end URL would not have them encoded, like in this example, where the normalized URLs includes apostrophes and whitespace.

``` elixir
iex(1)> NormalizeUrl.normalize_url("google.com?b=foo's+bar&a=joe+smith")
"http://google.com?a=joe smith&b=foo's bar"
```

With the fix on this PR, the params are encoded back:

``` elixir
iex(1)> NormalizeUrl.normalize_url("google.com?b=foo's+bar&a=joe+smith")
"http://google.com?a=joe+smith&b=foo%27s+bar"
```

Also, `URI.encode_query/1` takes care of ordering the params, so there's no need to manually order the params.
