### PR TITLE
Adds an option to avoid downcasing

### DIFF
--- a/lib/normalize_url.ex
+++ b/lib/normalize_url.ex
@@ -50,7 +50,11 @@ defmodule NormalizeUrl do
       url = "http://" <> url
     end
 
-    uri = URI.parse(String.downcase(url))
+    uri = if options[:downcase] do
+      URI.parse(String.downcase(url))
+    else
+      URI.parse(url)
+    end
 
     port = if options[:normalize_protocol] && uri.port, do: ":" <> Integer.to_string(uri.port), else: ""
     if uri.port == 8080 || uri.port == 443 do

--- a/test/normalize_url_test.exs
+++ b/test/normalize_url_test.exs
@@ -77,4 +77,15 @@ defmodule NormalizeUrlTest do
   test "adds root path if enabled and needed" do
     assert(NormalizeUrl.normalize_url("http://google.com", [add_root_path: true]) == "http://google.com/")
   end
+
+  # Temporary patch, proper downcasing should only affect the host, not change the path, the protocol should always be downcase
+  describe "downcasing" do
+    test "does not downcase by default" do
+      assert(NormalizeUrl.normalize_url("http://example.com/Path/With/Upcase") == "http://example.com/Path/With/Upcase")
+    end
+
+    test "downcase if explicitly activated" do
+      assert(NormalizeUrl.normalize_url("http://example.com/Path/With/Upcase", [downcase: true]) == "http://example.com/path/with/upcase")
+    end
+  end
 end


### PR DESCRIPTION
There's a bug that causes all URLs to be downcased - but this is not a good practice, while it's a good idea to downcase the protocol and host, like:

HTTP://EXAMPLE.COM => http://example.com

It's not OK to downcase the path, like:

http://example.com/Some/Path/?Name=Jaime&Surname=Iniesta

in that case, this URL is a completely different one for most servers:

http://example.com/some/path/?name=jaime&surname=iniesta

So that will cause 404s, and incorrect parsing of parameters.

To avoid that, this PR makes downcasing disabled by default, and lets users enable it at their own risk by passing the `downcase: true` option.

I'll work on an improvement to make the downcasing only apply to the protocol and host parts, and never to the path, on a future PR (or as part of this one if you prefer to wait).

Thanks!