### PR TITLE
Handle URLs with ports

### DIFF
--- a/lib/normalize_url.ex
+++ b/lib/normalize_url.ex
@@ -40,8 +40,9 @@ defmodule NormalizeUrl do
 
     scheme = ""
     url = if Regex.match?(~r/^\/\//, url), do: "http:" <> url, else: url
+
     if options[:normalize_protocol] do
-      scheme = if Regex.match?(~r/^ftp:\/\//, url), do: "ftp://", else: "http:"
+      scheme = if Regex.match?(~r/^ftp:\/\//, url), do: "ftp://", else: "http://"
     else
       scheme = "//"
     end

--- a/lib/normalize_url.ex
+++ b/lib/normalize_url.ex
@@ -21,13 +21,25 @@ defmodule NormalizeUrl do
   Returns a url as a string.
   """
   def normalize_url(url, options \\ []) do
-    %{scheme: scheme} = URI.parse(url)
+    scheme = filter_scheme(url)
 
     if (scheme == "http") || (scheme == "ftp") || (scheme == nil) do
       normalize_http_or_ftp_url(url, options)
     else
       url
     end
+  end
+
+  # Extracts the scheme from a URL, returning nil if it's not an accepted scheme.
+  # Needed because URI.parse("example.com:4000") will return "example.com" as the scheme.
+  defp filter_scheme(url) do
+    %{scheme: scheme} = URI.parse(url)
+
+    if Enum.any?(accepted_schemes, &(&1 == scheme)), do: scheme, else: nil
+  end
+
+  defp accepted_schemes do
+    iana_schemes ++ ["javascript"]
   end
 
   defp normalize_http_or_ftp_url(url, options \\ []) do
@@ -94,6 +106,279 @@ defmodule NormalizeUrl do
     end
 
     scheme <> host_and_path <> query_params
+  end
+
+  # Taken from https://www.iana.org/assignments/uri-schemes/uri-schemes.txt
+  defp iana_schemes do
+    """
+    aaa
+    aaas
+    about
+    acap
+    acct
+    acr
+    adiumxtra
+    afp
+    afs
+    aim
+    appdata
+    apt
+    attachment
+    aw
+    barion
+    beshare
+    bitcoin
+    blob
+    bolo
+    browserext
+    callto
+    cap
+    chrome
+    chrome-extension
+    cid
+    coap
+    coap+tcp
+    coaps
+    coaps+tcp
+    com-eventbrite-attendee
+    content
+    crid
+    cvs
+    data
+    dav
+    dict
+    dis
+    dlna-playcontainer
+    dlna-playsingle
+    dns
+    dntp
+    dtn
+    dvb
+    ed2k
+    example
+    facetime
+    fax
+    feed
+    feedready
+    file
+    filesystem
+    finger
+    fish
+    ftp
+    geo
+    gg
+    git
+    gizmoproject
+    go
+    gopher
+    graph
+    gtalk
+    h323
+    ham
+    hcp
+    http
+    https
+    hxxp
+    hxxps
+    hydrazone
+    iax
+    icap
+    icon
+    im
+    imap
+    info
+    iotdisco
+    ipn
+    ipp
+    ipps
+    irc
+    irc6
+    ircs
+    iris
+    iris.beep
+    iris.lwz
+    iris.xpc
+    iris.xpcs
+    isostore
+    itms
+    jabber
+    jar
+    jms
+    keyparc
+    lastfm
+    ldap
+    ldaps
+    lvlt
+    magnet
+    mailserver
+    mailto
+    maps
+    market
+    message
+    mid
+    mms
+    modem
+    mongodb
+    moz
+    ms-access
+    ms-browser-extension
+    ms-drive-to
+    ms-enrollment
+    ms-excel
+    ms-gamebarservices
+    ms-getoffice
+    ms-help
+    ms-infopath
+    ms-inputapp
+    ms-media-stream-id
+    ms-officeapp
+    ms-people
+    ms-project
+    ms-powerpoint
+    ms-publisher
+    ms-search-repair
+    ms-secondary-screen-contr
+    ms-secondary-screen-setup
+    ms-settings
+    ms-settings-airplanemode
+    ms-settings-bluetooth
+    ms-settings-camera
+    ms-settings-cellular
+    ms-settings-cloudstorage
+    ms-settings-connectablede
+    ms-settings-displays-topo
+    ms-settings-emailandaccou
+    ms-settings-language
+    ms-settings-location
+    ms-settings-lock
+    ms-settings-nfctransactio
+    ms-settings-notifications
+    ms-settings-power
+    ms-settings-privacy
+    ms-settings-proximity
+    ms-settings-screenrotatio
+    ms-settings-wifi
+    ms-settings-workplace
+    ms-spd
+    ms-sttoverlay
+    ms-transit-to
+    ms-virtualtouchpad
+    ms-visio
+    ms-walk-to
+    ms-whiteboard
+    ms-whiteboard-cmd
+    ms-word
+    msnim
+    msrp
+    msrps
+    mtqp
+    mumble
+    mupdate
+    mvn
+    news
+    nfs
+    ni
+    nih
+    nntp
+    notes
+    ocf
+    oid
+    onenote
+    onenote-cmd
+    opaquelocktoken
+    pack
+    palm
+    paparazzi
+    pkcs11
+    platform
+    pop
+    pres
+    prospero
+    proxy
+    pwid
+    psyc
+    qb
+    query
+    redis
+    rediss
+    reload
+    res
+    resource
+    rmi
+    rsync
+    rtmfp
+    rtmp
+    rtsp
+    rtsps
+    rtspu
+    secondlife
+    service
+    session
+    sftp
+    sgn
+    shttp
+    sieve
+    sip
+    sips
+    skype
+    smb
+    sms
+    smtp
+    snews
+    snmp
+    soap.beep
+    soap.beeps
+    soldat
+    spotify
+    ssh
+    steam
+    stun
+    stuns
+    submit
+    svn
+    tag
+    teamspeak
+    tel
+    teliaeid
+    telnet
+    tftp
+    things
+    thismessage
+    tip
+    tn3270
+    tool
+    turn
+    turns
+    tv
+    udp
+    unreal
+    urn
+    ut2004
+    v-event
+    vemmi
+    ventrilo
+    videotex
+    vnc
+    view-source
+    wais
+    webcal
+    wpid
+    ws
+    wss
+    wtai
+    wyciwyg
+    xcon
+    xcon-userid
+    xfire
+    xmlrpc.beep
+    xmlrpc.beeps
+    xmpp
+    xri
+    ymsgr
+    z39.50
+    z39.50r
+    z39.50s
+    """ |> String.split(~r/\n/, trim: true)
   end
 
 end

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule NormalizeUrl.Mixfile do
       elixir: "~> 1.1",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
-      deps: deps,
+      deps: deps(),
       description: "Normalize a url",
       package: [
         maintainers: ["John Otander"],

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,2 @@
-%{"earmark": {:hex, :earmark, "0.1.19"},
-  "ex_doc": {:hex, :ex_doc, "0.10.0"}}
+%{"earmark": {:hex, :earmark, "0.1.19", "ffec54f520a11b711532c23d8a52b75a74c09697062d10613fa2dbdf8a9db36e", [], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.10.0", "f49c237250b829df986486b38f043e6f8e19d19b41101987f7214543f75947ec", [], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, repo: "hexpm", optional: true]}], "hexpm"}}

--- a/test/normalize_url_test.exs
+++ b/test/normalize_url_test.exs
@@ -2,8 +2,11 @@ defmodule NormalizeUrlTest do
   use ExUnit.Case
   doctest NormalizeUrl
 
-  test "adds a protocol" do
-    assert(NormalizeUrl.normalize_url("google.com") == "http://google.com")
+  test "adds a protocol by default" do
+    assert(NormalizeUrl.normalize_url("example.com")          == "http://example.com")
+    assert(NormalizeUrl.normalize_url("example.com/dir")      == "http://example.com/dir")
+    assert(NormalizeUrl.normalize_url("example.com:3000")     == "http://example.com:3000")
+    assert(NormalizeUrl.normalize_url("example.com:3000/dir") == "http://example.com:3000/dir")
   end
 
   test "keeps the http protocol" do
@@ -82,10 +85,8 @@ defmodule NormalizeUrlTest do
     assert NormalizeUrl.normalize_url("http://example.com:3000")      == "http://example.com:3000"
     assert NormalizeUrl.normalize_url("https://example.com:3000")     == "https://example.com:3000"
     assert NormalizeUrl.normalize_url("https://example.com:3000/dir") == "https://example.com:3000/dir"
-
-    # TODO: in these cases we should prefix with "http://"
-    assert NormalizeUrl.normalize_url("example.com:3000")             == "example.com:3000"
-    assert NormalizeUrl.normalize_url("example.com:3000/dir")         == "example.com:3000/dir"
+    assert NormalizeUrl.normalize_url("example.com:3000")             == "http://example.com:3000"
+    assert NormalizeUrl.normalize_url("example.com:3000/dir")         == "http://example.com:3000/dir"
   end
 
   # Temporary patch, proper downcasing should only affect the host, not change the path, the protocol should always be downcase

--- a/test/normalize_url_test.exs
+++ b/test/normalize_url_test.exs
@@ -78,6 +78,16 @@ defmodule NormalizeUrlTest do
     assert(NormalizeUrl.normalize_url("http://google.com", [add_root_path: true]) == "http://google.com/")
   end
 
+  test "handles URLs with port" do
+    assert NormalizeUrl.normalize_url("http://example.com:3000")      == "http://example.com:3000"
+    assert NormalizeUrl.normalize_url("https://example.com:3000")     == "https://example.com:3000"
+    assert NormalizeUrl.normalize_url("https://example.com:3000/dir") == "https://example.com:3000/dir"
+
+    # TODO: in these cases we should prefix with "http://"
+    assert NormalizeUrl.normalize_url("example.com:3000")             == "example.com:3000"
+    assert NormalizeUrl.normalize_url("example.com:3000/dir")         == "example.com:3000/dir"
+  end
+
   # Temporary patch, proper downcasing should only affect the host, not change the path, the protocol should always be downcase
   describe "downcasing" do
     test "does not downcase by default" do


### PR DESCRIPTION
This PR fixes URL normalization when the URL contains a port. This is a failing case:

```elixir
iex(1)> NormalizeUrl.normalize_url("http://example.com:3000")
"http:example.com:3000"
```

See the rest of tests for other related cases.

