### PR TITLE
upgrade to elixir 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 sudo: false
 language: elixir
 elixir:
-  - 1.3
+  - 1.7.4
 otp_release:
-  - 17.4
+  - 21.2
 before_script:
   - mix local.hex --force
   - mix deps.get --only test

--- a/mix.exs
+++ b/mix.exs
@@ -5,15 +5,15 @@ defmodule NormalizeUrl.Mixfile do
     [
       app: :normalize_url,
       version: "0.3.2",
-      elixir: "~> 1.1",
-      build_embedded: Mix.env == :prod,
-      start_permanent: Mix.env == :prod,
+      elixir: "~> 1.7",
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
       deps: deps(),
       description: "Normalize a url",
       package: [
         maintainers: ["John Otander"],
         licenses: ["MIT"],
-        links: %{ "Github" => "https://github.com/johnotander/normalize_url" }
+        links: %{"Github" => "https://github.com/johnotander/normalize_url"}
       ]
     ]
   end


### PR DESCRIPTION
Code changes were needed because in Elixir 1.7 we had these warnings:

```
Note variables defined inside case, cond, fn, if and similar do not leak. If you want to conditionally override an existing variable "path", you will have to explicitly return the variable. For example:

    if some_condition? do
      atom = :one
    else
      atom = :two
    end

should be written as

    atom =
      if some_condition? do
        :one
      else
        :two
      end
```